### PR TITLE
[docs]: fix search functionality

### DIFF
--- a/docs/src/app/api/search/route.ts
+++ b/docs/src/app/api/search/route.ts
@@ -1,0 +1,4 @@
+import { docsSource } from '@/lib/source';
+import { createFromSource } from 'fumadocs-core/search/server';
+
+export const { GET } = createFromSource(docsSource);


### PR DESCRIPTION
### Problem
documentation search not working as described in #182 


### Summary of Changes
added the missing API route required to enable search functionality in the docs site.



Fixes #
#182 