### PR TITLE
ci: github token

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Comment on PR with Preview URL
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PREVIEW_URL: "${{ steps.vercel_deploy.outputs.preview_url }}"
         run: |

--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   # Among other things, opts out of Turborepo telemetry
   # See https://consoledonottrack.com/
-  DO_NOT_TRACK: '1'
+  DO_NOT_TRACK: "1"
   # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
   TURBO_CONCURRENCY: 1
   # Enables Turborepo Remote Caching.
@@ -55,8 +55,8 @@ jobs:
           pnpm changeset version --snapshot canary
           pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB }}
+          TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_TAG: canary
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
   push:
     branches:
       - master
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 env:
   # Among other things, opts out of Turborepo telemetry
@@ -43,7 +43,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN_GITHUB: ${{ secrets.TOKEN_GITHUB }}
 
       - name: Run Pre-Build Step
         run: pnpm prebuild --force=true
@@ -57,7 +57,7 @@ jobs:
       - name: Run Build Step (force)
         run: pnpm turbo ${{ steps.build-step-decider.outputs.step-name }} --force=true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_TAG: next
 
@@ -67,4 +67,4 @@ jobs:
       #     VERSION_TAG=v$(cd packages/library/ && pnpm pkg get version | sed -n '2p' | grep -o '"\([^"]\)\+"$' | tr -d \")
       #     if ! git ls-remote --tags | grep -q "$VERSION_TAG"; then git tag $VERSION_TAG && git push --tags; fi
       #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     GH_TOKEN: ${{ secrets.TOKEN_GITHUB }}


### PR DESCRIPTION
### Problem

ci broke when the gill repo was transferred from `solana-foundation` to `DecalLabs`.

### Summary of Changes
