### PR TITLE
[react][feat] add useSignaturesForAddress hook

### DIFF
--- a/.changeset/tough-plants-shop.md
+++ b/.changeset/tough-plants-shop.md
@@ -1,0 +1,5 @@
+---
+"gill-react": minor
+---
+
+added `useSignaturesForAddress` hook

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -60,6 +60,7 @@ Fetch data from the Solana blockchain with the gill hooks:
 - [`useBalance`](#get-account-balance-in-lamports) - get account balance (in lamports)
 - [`useLatestBlockhash`](#get-latest-blockhash) - get the latest blockhash
 - [`useSignatureStatuses`](#get-signature-statuses) - get signature statuses
+- [`useSignaturesForAddress`](#get-signatures-for-address) - get signatures for address
 - [`useProgramAccounts`](#get-program-accounts-gpa) - get program accounts (GPA)
 - [`useTokenMint`](#get-token-mint-account) - get a decoded token's Mint account
 - [`useTokenAccount`](#get-token-account) - get the token account for a given mint and owner (or ATA)
@@ -420,6 +421,34 @@ export function PageClient() {
   return (
     <div className="">
       <pre>account: {JSON.stringify(account, null, "\t")}</pre>
+    </div>
+  );
+}
+```
+
+### Get Signatures for address
+
+Get the signatures for confirmed transactions using the RPC method of [getSignaturesForAddress](https://solana.com/docs/rpc/http/getsignaturesforaddress)
+
+```tsx
+"use client";
+
+import { useSignaturesForAddress } from "gill-react";
+
+export function PageClient() {
+  const { signatures, isLoading, isError, error } = useSignaturesForAddress({
+    address: "nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c",
+    config : {
+      limit: 10
+    }
+  });
+
+  // if (isLoading) { return ... }
+  // if (isError) { return ... }
+
+  return (
+    <div className="">
+      <pre>signatures: {JSON.stringify(signatures, null, "\t")}</pre>
     </div>
   );
 }

--- a/packages/react/src/__typeset__/signatures-for-address.ts
+++ b/packages/react/src/__typeset__/signatures-for-address.ts
@@ -1,0 +1,26 @@
+import { Address, GetSignaturesForAddressApi } from "gill";
+import { useSignaturesForAddress } from "../hooks";
+
+// [DESCRIBE] useSignaturesForAddress
+{
+  const address = null as unknown as Address;
+
+  {
+    const { signatures } = useSignaturesForAddress({ address });
+    signatures satisfies ReturnType<GetSignaturesForAddressApi["getSignaturesForAddress"]>;
+
+    // @ts-expect-error - Should not allow no argument
+    useSignaturesForAddress();
+
+    // @ts-expect-error - Should not allow empty argument object
+    useSignaturesForAddress({});
+  }
+
+  {
+    const { signatures } = useSignaturesForAddress({
+      address,
+      config: { limit: 10 },
+    });
+    signatures satisfies ReturnType<GetSignaturesForAddressApi["getSignaturesForAddress"]>;
+  }
+}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -4,5 +4,6 @@ export * from "./client";
 export * from "./latest-blockhash";
 export * from "./program-accounts";
 export * from "./signature-statuses";
+export * from "./signatures-for-address";
 export * from "./token-account";
 export * from "./token-mint";

--- a/packages/react/src/hooks/signatures-for-address.ts
+++ b/packages/react/src/hooks/signatures-for-address.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Address, GetSignaturesForAddressApi, Simplify } from "gill";
+import { GILL_HOOK_CLIENT_KEY } from "../const";
+import { useSolanaClient } from "./client";
+import { GillUseRpcHook } from "./types";
+
+type RpcConfig = Simplify<Parameters<GetSignaturesForAddressApi["getSignaturesForAddress"]>[1]>;
+
+type UseSignaturesForAddressInput<TConfig extends RpcConfig = RpcConfig> = GillUseRpcHook<TConfig> & {
+  /**
+   * Address of the account to fetch signatures of
+   */
+  address: Address | string;
+};
+
+type UseSignaturesForAddressResponse = ReturnType<GetSignaturesForAddressApi["getSignaturesForAddress"]>;
+
+/**
+ * Returns signatures for confirmed transactions that include the given address
+ * in their accountKeys list. Returns signatures backwards in time from the
+ * provided signature or most recent confirmed block using the Solana RPC method of
+ * [`getsignaturesforaddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress)
+ */
+export function useSignaturesForAddress<TConfig extends RpcConfig = RpcConfig>({
+  options,
+  config,
+  abortSignal,
+  address,
+}: UseSignaturesForAddressInput<TConfig>) {
+  const { rpc } = useSolanaClient();
+  const { data, ...rest } = useQuery({
+    networkMode: "offlineFirst",
+    ...options,
+    enabled: !!address,
+    queryKey: [GILL_HOOK_CLIENT_KEY, "getSignaturesForAddress", address],
+    queryFn: async () => {
+      const signatures = await rpc.getSignaturesForAddress(address as Address, config).send({ abortSignal });
+      return signatures;
+    },
+  });
+  return {
+    ...rest,
+    signatures: data as UseSignaturesForAddressResponse,
+  };
+}

--- a/packages/react/src/hooks/signatures-for-address.ts
+++ b/packages/react/src/hooks/signatures-for-address.ts
@@ -19,9 +19,9 @@ type UseSignaturesForAddressResponse = ReturnType<GetSignaturesForAddressApi["ge
 
 /**
  * Returns signatures for confirmed transactions that include the given address
- * in their accountKeys list. Returns signatures backwards in time from the
+ * in their `accountKeys` list. Returns signatures backwards in time from the
  * provided signature or most recent confirmed block using the Solana RPC method of
- * [`getsignaturesforaddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress)
+ * [`getSignaturesForAddress`](https://solana.com/docs/rpc/http/getsignaturesforaddress)
  */
 export function useSignaturesForAddress<TConfig extends RpcConfig = RpcConfig>({
   options,


### PR DESCRIPTION
### Problem

Implement getSignaturesforAddress RPC call as a hook

### Summary of Changes

- implemented the hook: `useSignaturesForAddress` in `signatures-for-address.ts` file
- added typeset file for `signatures-for-address.ts`
- export the hook from main `index.ts`
- add example in docs
- followed existing naming convention and changeset rules for consistency