### PR TITLE
[react][feat] add useTokenAccountsByOwner hook

### DIFF
--- a/.changeset/new-planets-tickle.md
+++ b/.changeset/new-planets-tickle.md
@@ -1,0 +1,5 @@
+---
+"gill-react": minor
+---
+
+added `useTokenAccountsByOwner` hook

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,6 +63,7 @@ Fetch data from the Solana blockchain with the gill hooks:
 - [`useProgramAccounts`](#get-program-accounts-gpa) - get program accounts (GPA)
 - [`useTokenMint`](#get-token-mint-account) - get a decoded token's Mint account
 - [`useTokenAccount`](#get-token-account) - get the token account for a given mint and owner (or ATA)
+- [`useTokenAccountsByOwner`](#get-token-accounts-by-owner) - get all SPL Token accounts by token owner.
 
 ### Wrap your React app in a context provider
 
@@ -420,6 +421,36 @@ export function PageClient() {
   return (
     <div className="">
       <pre>account: {JSON.stringify(account, null, "\t")}</pre>
+    </div>
+  );
+}
+```
+
+### Get Token Accounts by Owner
+
+Get all SPL Token accounts by token owner using the Solana RPC method of [getTokenAccountsByOwner](https://solana.com/docs/rpc/http/gettokenaccountsbyowner).
+
+```tsx
+"use client";
+
+import { useTokenAccountsByOwner } from "gill-react";
+
+export function PageClient() {
+  const { tokenAccounts, isLoading, isError, error } = useTokenAccountsByOwner({
+    owner: "nicktrLHhYzLmoVbuZQzHUTicd2sfP571orwo9jfc8c",
+    filter: { programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" }, // or { mint: "<TokenMintAddress>" }
+    config: { 
+      commitment: "finalized",
+      encoding: "jsonParsed", // encoding: "base58" | "base64" | "base64+zstd" | "jsonParsed"
+    },
+  });
+
+  // if (isLoading) { return ... }
+  // if (isError) { return ... }
+
+  return (
+    <div className="">
+      <pre>tokenAccounts: {JSON.stringify(tokenAccounts, null, 2)}</pre>
     </div>
   );
 }

--- a/packages/react/src/__typeset__/token-accounts-by-owner.ts
+++ b/packages/react/src/__typeset__/token-accounts-by-owner.ts
@@ -1,0 +1,121 @@
+import {
+  AccountInfoWithBase58Bytes,
+  AccountInfoWithBase58EncodedData,
+  AccountInfoWithBase64EncodedData,
+  AccountInfoWithBase64EncodedZStdCompressedData,
+  AccountInfoWithJsonData,
+  Address,
+  Base58EncodedBytes,
+  Base58EncodedDataResponse,
+  Base64EncodedDataResponse,
+  Base64EncodedZStdCompressedDataResponse,
+  SolanaRpcResponse,
+} from "gill";
+import { useTokenAccountsByOwner } from "../hooks";
+
+// [DESCRIBE] useTokenAccountsByOwner
+{
+  const owner = null as unknown as Address;
+  const mint = null as unknown as Address;
+  const programId = null as unknown as Address;
+
+  // default encoded data as bytes
+  {
+    const { tokenAccounts: baseConfigAccounts } = useTokenAccountsByOwner({
+      owner,
+      filter: { mint }
+    });
+    // Should return accounts with data encoded as base58 bytes by default
+    baseConfigAccounts satisfies SolanaRpcResponse<any>;
+    baseConfigAccounts.value[0].account satisfies AccountInfoWithBase58Bytes;
+    baseConfigAccounts.value[0].account.data satisfies Base58EncodedBytes;
+
+    // @ts-expect-error - Should not allow no argument
+    useTokenAccountsByOwner();
+    // @ts-expect-error - Should not allow empty argument object
+    useTokenAccountsByOwner({});
+    // @ts-expect-error - Should not allow missing filter
+    useTokenAccountsByOwner({ owner });
+    // @ts-expect-error - Should not allow missing owner
+    useTokenAccountsByOwner({ filter: { mint } });
+  }
+
+  // base58 encoded `data`
+  {
+    const { tokenAccounts: base58Accounts } = useTokenAccountsByOwner({
+      owner,
+      filter: { programId },
+      config: {
+        commitment: "finalized",
+        encoding: "base58",
+      }
+    });
+    
+    // Should return accounts with data encoded as base58 (explicit encoding)
+    base58Accounts satisfies SolanaRpcResponse<any>;
+    base58Accounts.value[0].account satisfies AccountInfoWithBase58EncodedData;
+    base58Accounts.value[0].account.data satisfies Base58EncodedDataResponse;
+
+    // @ts-expect-error Should not be base58 encoded bytes
+    base58Accounts.value[0].account.data satisfies Base58EncodedBytes;
+  }
+
+  // base64 encoded `data`
+  {
+    const { tokenAccounts: base64Accounts } = useTokenAccountsByOwner({
+      owner,
+      filter: { programId },
+      config: {
+        commitment: "finalized",
+        encoding: "base64",
+      },
+    });
+    
+    // Should return accounts with data encoded as base64
+    base64Accounts satisfies SolanaRpcResponse<any>;
+    base64Accounts.value[0].account satisfies AccountInfoWithBase64EncodedData;
+    base64Accounts.value[0].account.data satisfies Base64EncodedDataResponse;
+
+    // @ts-expect-error Should not be base58 encoded bytes
+    base64Accounts.value[0].account.data satisfies Base58EncodedBytes;
+  }
+
+  // base64+zstd encoded `data`
+  {
+    const { tokenAccounts: base64ZstdAccounts } = useTokenAccountsByOwner({
+      owner,
+      filter: { programId },
+      config: {
+        commitment: "finalized",
+        encoding: "base64+zstd",
+      },
+    });
+    
+    // Should return accounts with data encoded as base64+zstd
+    base64ZstdAccounts satisfies SolanaRpcResponse<any>;
+    base64ZstdAccounts.value[0].account satisfies AccountInfoWithBase64EncodedZStdCompressedData;
+    base64ZstdAccounts.value[0].account.data satisfies Base64EncodedZStdCompressedDataResponse;
+
+    // @ts-expect-error Should not be base58 encoded bytes
+    base64ZstdAccounts.value[0].account.data satisfies Base58EncodedBytes;
+  }
+
+  // json parsed encoded `data`
+  {
+    const { tokenAccounts:jsonParsedAccounts } = useTokenAccountsByOwner({
+      owner,
+      filter: { programId },
+      config: {
+        commitment: "finalized",
+        encoding: "jsonParsed",
+      },
+    });
+    
+    // Should return accounts with data encoded as base64 or jsonParsed
+    jsonParsedAccounts satisfies SolanaRpcResponse<any>;
+    jsonParsedAccounts.value[0].account satisfies AccountInfoWithBase64EncodedData | AccountInfoWithJsonData;
+    
+    // @ts-expect-error Should not be base58 encoded bytes
+    jsonParsedAccounts.value[0].account.data satisfies Base58EncodedBytes;
+  }
+}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -6,5 +6,6 @@ export * from "./program-accounts";
 export * from "./signature-statuses";
 export * from "./slot";
 export * from "./token-account";
+export * from "./token-accounts-by-owner";
 export * from "./token-mint";
 export * from "./recent-prioritization-fees";

--- a/packages/react/src/hooks/token-accounts-by-owner.ts
+++ b/packages/react/src/hooks/token-accounts-by-owner.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type {
+  AccountInfoBase,
+  AccountInfoWithBase58Bytes,
+  AccountInfoWithBase58EncodedData,
+  AccountInfoWithBase64EncodedData,
+  AccountInfoWithBase64EncodedZStdCompressedData,
+  AccountInfoWithJsonData,
+  AccountInfoWithPubkey,
+  Address,
+  GetTokenAccountsByOwnerApi,
+  Simplify,
+  SolanaRpcResponse,
+} from "gill";
+import { GILL_HOOK_CLIENT_KEY } from "../const";
+import { useSolanaClient } from "./client";
+import type { GillUseRpcHook } from "./types";
+
+type Encoding = "base64" | "jsonParsed" | "base64+zstd" | "base58";
+
+type RpcConfig = Simplify<
+  Parameters<GetTokenAccountsByOwnerApi["getTokenAccountsByOwner"]>[2] &
+    Readonly<{
+      encoding?: Encoding;
+    }>
+>;
+
+type UseTokenAccountsByOwnerInput<TConfig extends RpcConfig = RpcConfig> = GillUseRpcHook<TConfig> & {
+  /**
+   * Address of account to fetch token accounts of
+   */
+  owner: Address | string;
+  /**
+   * Filter by mint or programId
+   */
+  filter: { mint: Address | string } | { programId: Address | string };
+};
+
+type UseTokenAccountsByOwnerResponse<TConfig extends RpcConfig> = TConfig extends {
+  encoding: "base64"
+}
+  ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedData>[]>
+  : TConfig extends { encoding: "base64+zstd" }
+    ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedZStdCompressedData>[]>
+    : TConfig extends { encoding: "jsonParsed" }
+      ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>[]>
+      : TConfig extends { encoding: "base58" }
+        ? SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58EncodedData>[]>
+        : SolanaRpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[]>;
+
+/**
+* Get all SPL Token accounts by token owner using the Solana RPC method of
+* [getTokenAccountsByOwner](https://solana.com/docs/rpc/http/gettokenaccountsbyowner)
+*/
+export function useTokenAccountsByOwner<TConfig extends RpcConfig = RpcConfig>({
+  options,
+  config,
+  abortSignal,
+  owner,
+  filter,
+}: UseTokenAccountsByOwnerInput<TConfig>) {
+  const { rpc } = useSolanaClient();
+
+  const { data, ...rest } = useQuery({
+    ...options,
+    enabled: !!owner && !!filter,
+    queryKey: [GILL_HOOK_CLIENT_KEY, "getTokenAccountsByOwner", owner, filter],
+    queryFn: async () => {
+      const tokenAccounts = await rpc.getTokenAccountsByOwner(
+        owner as Address, 
+        'mint' in filter
+          ? { mint: filter.mint as Address }
+          : { programId: filter.programId as Address },
+        config
+      ).send({ abortSignal });
+      return tokenAccounts;
+    },
+  });
+
+  return {
+    ...rest,
+    tokenAccounts: data as Simplify<UseTokenAccountsByOwnerResponse<TConfig>>,
+  };
+}


### PR DESCRIPTION
### Problem
Implement getTokenAccountsByOwner RPC call as a hook

### Summary of Changes
- implemented the hook: `useTokenAccountsByOwner` in `token-accounts-by-owner.ts` file
- added typeset file for `token-accounts-by-owner.ts` - ensures type safety and correct response shapes for all supported encodings
- export the hook from main `index.ts`
- add example in docs
- followed existing naming convention and changeset rules for consistency