### PR TITLE
feat: add sendAndConfirmInstructions helper and tests

### DIFF
--- a/packages/gill/src/__tests__/send-and-confirm-instructions.ts
+++ b/packages/gill/src/__tests__/send-and-confirm-instructions.ts
@@ -1,0 +1,190 @@
+import { ITransactionMessageWithFeePayerSigner, type IInstruction, type Signature } from "@solana/kit";
+import { blockhash, generateKeyPairSigner, type KeyPairSigner } from "@solana/kit";
+import { createTransaction } from "../core/create-transaction";
+import { prepareTransaction } from "../core/prepare-transaction";
+import { sendAndConfirmInstructions } from "../core/send-and-confirm-instructions";
+import { FullTransaction, SolanaClient } from "../types";
+import { MAX_COMPUTE_UNIT_LIMIT } from "../programs";
+
+jest.mock("../core/create-transaction", () => ({
+  createTransaction: jest.fn(),
+}));
+
+jest.mock("../core/prepare-transaction", () => ({
+  prepareTransaction: jest.fn(),
+  asPreparableTransaction: (tx: FullTransaction<any, any>) => tx,
+}));
+
+describe("sendAndConfirmInstructions", () => {
+  let signer: KeyPairSigner;
+  let mockClient: SolanaClient;
+  let mockInstruction: IInstruction;
+  let mockTransaction: FullTransaction<"legacy", ITransactionMessageWithFeePayerSigner>;
+
+  beforeAll(async () => {
+    signer = await generateKeyPairSigner();
+
+    mockInstruction = {
+      programAddress: "11111111111111111111111111111112" as any,
+      accounts: [],
+      data: new Uint8Array([]),
+    };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTransaction = {
+      feePayer: signer,
+      instructions: [mockInstruction],
+      version: "legacy",
+    };
+
+    (createTransaction as jest.Mock).mockReturnValue(mockTransaction);
+    (prepareTransaction as jest.Mock).mockImplementation(({ transaction }) =>
+      Promise.resolve({
+        ...transaction,
+        message: {
+          ...transaction.message,
+          recentBlockhash: blockhash("GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z"),
+        },
+      }),
+    );
+
+    mockClient = {
+      rpc: {
+        getLatestBlockhash: {
+          send: jest.fn().mockResolvedValue({
+            value: {
+              blockhash: blockhash("GK1nopeF3P8J46dGqq4KfaEWopZU7K65F6CKQXuUdr3z"),
+              lastValidBlockHeight: 1000n,
+            },
+          }),
+        },
+        simulateTransaction: {
+          send: jest.fn().mockResolvedValue({
+            value: {
+              unitsConsumed: 5000,
+              logs: [],
+              err: null,
+            },
+          }),
+        },
+      },
+      sendAndConfirmTransaction: jest
+        .fn()
+        .mockResolvedValue("5j8WuZZZZ1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z1Z" as Signature),
+      rpcSubscriptions: jest.fn() as any,
+      simulateTransaction: jest.fn() as any,
+    } as unknown as SolanaClient;
+  });
+
+  test("sends and confirms instructions with default options", async () => {
+    const signature = await sendAndConfirmInstructions(mockClient, signer, [mockInstruction]);
+
+    expect(createTransaction).toHaveBeenCalledWith({
+      version: "legacy",
+      feePayer: signer,
+      instructions: [mockInstruction],
+      computeUnitLimit: MAX_COMPUTE_UNIT_LIMIT,
+      computeUnitPrice: 1,
+    });
+
+    expect(prepareTransaction).toHaveBeenCalledWith({
+      transaction: expect.anything(),
+      rpc: mockClient.rpc,
+      computeUnitLimitMultiplier: 1.1,
+      computeUnitLimitReset: true,
+      blockhashReset: true,
+    });
+
+    expect(mockClient.sendAndConfirmTransaction).toHaveBeenCalled();
+    expect(typeof signature).toBe("string");
+  });
+
+  test("sends and confirms instructions with legacy version", async () => {
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {
+      version: "legacy",
+    });
+
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: "legacy",
+      }),
+    );
+  });
+
+  test("sends and confirms instructions with version 0", async () => {
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {
+      version: 0,
+    });
+
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 0,
+      }),
+    );
+  });
+
+  test("sends and confirms instructions with custom compute unit price", async () => {
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {
+      computeUnitPrice: 1000,
+    });
+
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        computeUnitPrice: 1000,
+      }),
+    );
+  });
+
+  test("sends and confirms instructions with explicit compute unit limit", async () => {
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {
+      computeUnitLimit: 200000,
+    });
+
+    expect(createTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        computeUnitLimit: 200000,
+      }),
+    );
+
+    expect(prepareTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        computeUnitLimitReset: false,
+      }),
+    );
+  });
+
+  test("sends and confirms instructions with custom multiplier", async () => {
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {
+      computeUnitLimitMultiplier: 1.5,
+    });
+
+    expect(prepareTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        computeUnitLimitMultiplier: 1.5,
+      }),
+    );
+  });
+
+  test("handles transaction sending failure", async () => {
+    const error = new Error("Transaction failed");
+    (mockClient.sendAndConfirmTransaction as jest.Mock).mockRejectedValue(error);
+
+    await expect(sendAndConfirmInstructions(mockClient, signer, [mockInstruction])).rejects.toThrow(
+      "Failed to send and confirm instructions:\n       \n      Transaction failed",
+    );
+  });
+
+  test("passes through send and confirm config", async () => {
+    const config = {
+      skipPreflight: true,
+      maxRetries: 5n,
+      commitment: "confirmed" as const,
+    };
+    await sendAndConfirmInstructions(mockClient, signer, [mockInstruction], {}, config);
+
+    expect(mockClient.sendAndConfirmTransaction).toHaveBeenCalledWith(expect.anything(), config);
+  });
+});

--- a/packages/gill/src/core/prepare-transaction.ts
+++ b/packages/gill/src/core/prepare-transaction.ts
@@ -18,7 +18,7 @@ import { isSetComputeLimitInstruction } from "../programs/compute-budget";
 import { transactionToBase64WithSigners } from "./base64-to-transaction";
 import { debug, isDebugEnabled } from "./debug";
 
-type PrepareCompilableTransactionMessage =
+export type PrepareCompilableTransactionMessage =
   | CompilableTransactionMessage
   | (ITransactionMessageWithFeePayer & TransactionMessage);
 

--- a/packages/gill/src/core/send-and-confirm-instructions.ts
+++ b/packages/gill/src/core/send-and-confirm-instructions.ts
@@ -1,0 +1,83 @@
+import {
+  ITransactionMessageWithFeePayer,
+  ITransactionMessageWithFeePayerSigner,
+  SolanaError,
+  type IInstruction,
+  type Signature,
+  type TransactionSigner,
+  type TransactionVersion,
+} from "@solana/kit";
+import { FullTransaction, SolanaClient } from "../types";
+import { createTransaction } from "./create-transaction";
+import { PrepareCompilableTransactionMessage, prepareTransaction } from "./prepare-transaction";
+import { MAX_COMPUTE_UNIT_LIMIT } from "../programs";
+import { SendAndConfirmTransactionConfig } from "./send-and-confirm-transaction-with-signers";
+
+export type SendAndConfirmInstructionsOptions = {
+  /* CU Price in microLamports (default: 1) */
+  computeUnitPrice?: number;
+  /* Transaction version (default: "legacy") */
+  version?: TransactionVersion;
+  /* CU Limit (when not provided, the transaction will be simulated to get the correct value) */
+  computeUnitLimit?: number;
+  /* CU Limit Margin Multiplier (default: 1.1) */
+  computeUnitLimitMultiplier?: number;
+};
+
+function asPreparableTransaction<
+  T extends FullTransaction<
+    TransactionVersion,
+    ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner
+  >,
+>(transaction: T): PrepareCompilableTransactionMessage {
+  return transaction as PrepareCompilableTransactionMessage;
+}
+
+/**
+ * A helper function to send and confirm an array of instructions
+ * with automatic compute unit estimation and blockhash fetching and defaultnominal priority fees
+ * @param client - The Solana client
+ * @param feePayer - The fee payer
+ * @param instructions - The instructions to send and confirm
+ * @param options - The options for the send and confirm instructions
+ *  - computeUnitPrice - The price of the compute unit in microLamports (default: 1)
+ *  - version - The version of the transaction (default: "legacy")
+ *  - computeUnitLimit - The compute unit limit (default: undefined, when not provided, the transaction will be simulated to get the correct value)
+ *  - computeUnitLimitMultiplier - The margin multiplier for the compute unit limit (default: 1.1)
+ * @param config - The config for the send and confirm instructions
+ * @returns The signature of the transaction
+ */
+export async function sendAndConfirmInstructions(
+  client: SolanaClient,
+  feePayer: TransactionSigner,
+  instructions: IInstruction[],
+  options: SendAndConfirmInstructionsOptions = {},
+  config?: SendAndConfirmTransactionConfig,
+): Promise<Signature> {
+  try {
+    const { computeUnitLimit, computeUnitPrice = 1, version = "legacy", computeUnitLimitMultiplier = 1.1 } = options;
+
+    const unpreparedTransaction = createTransaction({
+      version,
+      feePayer,
+      instructions,
+      computeUnitLimit: computeUnitLimit ?? MAX_COMPUTE_UNIT_LIMIT,
+      computeUnitPrice,
+    });
+
+    const transaction = await prepareTransaction({
+      transaction: asPreparableTransaction(unpreparedTransaction),
+      rpc: client.rpc,
+      computeUnitLimitMultiplier,
+      computeUnitLimitReset: computeUnitLimit === undefined,
+      blockhashReset: true,
+    });
+
+    const signature = await client.sendAndConfirmTransaction(transaction, config);
+    return signature;
+  } catch (error) {
+    throw new Error(`Failed to send and confirm instructions:
+      ${error instanceof SolanaError ? error.context + " - " : ""} 
+      ${error instanceof Error ? error.message : "Unknown error"}`);
+  }
+}

--- a/packages/gill/src/core/send-and-confirm-transaction-with-signers.ts
+++ b/packages/gill/src/core/send-and-confirm-transaction-with-signers.ts
@@ -46,12 +46,14 @@ type SendTransactionConfigWithoutEncoding = Omit<
   "encoding"
 >;
 
+export type SendAndConfirmTransactionConfig = Omit<
+  SendAndConfirmTransactionWithBlockhashLifetimeConfig,
+  "confirmRecentTransaction" | "rpc" | "transaction"
+>;
+
 export type SendAndConfirmTransactionWithSignersFunction = (
   transaction: (FullySignedTransaction & TransactionWithBlockhashLifetime) | CompilableTransactionMessage,
-  config?: Omit<
-    SendAndConfirmTransactionWithBlockhashLifetimeConfig,
-    "confirmRecentTransaction" | "rpc" | "transaction"
-  >,
+  config?: SendAndConfirmTransactionConfig,
 ) => Promise<Signature>;
 
 type SendAndConfirmTransactionWithSignersFactoryConfig<TCluster> = {


### PR DESCRIPTION
Adds a high-level helper function that simplifies the common pattern of sending and confirming an array of instructions as a single transaction with automatic compute unit estimation.

In Kit/Gill, I find myself frequently repeating the same pattern of:
1. Generating my instructions in transaction boilerplate
2. Creating a transaction for simulation (w/ my compute unit ix's)
3. Update final transacition w/ latest blockhash & CUs
4. Send and confirm the transaction

Gill currently has helpers for no. 2, 3, and 4 -- this PR creates a helper that ties them all together, and handles the entire flow, `sendAndConfirmInstructions()`:

```ts
const signature = await sendAndConfirmInstructions(client, feePayer, [ix1, ix2, ix3]);
```

Compared to the following before:

```ts
const unpreparedTransaction = createTransaction({
    version,
    feePayer,
    instructions,
    computeUnitLimit,
    computeUnitPrice,
});

const transaction = await prepareTransaction({
    transaction: unpreparedTransaction,
    rpc,
    computeUnitLimitReset: true,
    blockhashReset: true,
});

const signature = await client.sendAndConfirmTransaction(transaction, config);
```

This helper reduces commonly repeated boilerplate and provides a more ergonomic API for the common use case of executing multiple instructions atomically.