### PR TITLE
feat: make version optional

### DIFF
--- a/.changeset/violet-rivers-walk.md
+++ b/.changeset/violet-rivers-walk.md
@@ -1,0 +1,5 @@
+---
+"gill": patch
+---
+
+make `version` optional (default of `legacy`) in `createTransaction`

--- a/packages/gill/src/__typetests__/create-transaction.ts
+++ b/packages/gill/src/__typetests__/create-transaction.ts
@@ -2,11 +2,11 @@
 import type {
   Address,
   BaseTransactionMessage,
-  IInstruction,
-  ITransactionMessageWithFeePayer,
-  ITransactionMessageWithFeePayerSigner,
+  Instruction,
   KeyPairSigner,
   TransactionMessageWithBlockhashLifetime,
+  TransactionMessageWithFeePayer,
+  TransactionMessageWithFeePayerSigner,
 } from "@solana/kit";
 import { signTransactionMessageWithSigners } from "@solana/kit";
 
@@ -18,23 +18,31 @@ import { createTransaction } from "../core";
   const signer = null as unknown as KeyPairSigner;
   const latestBlockhash = null as unknown as TransactionMessageWithBlockhashLifetime["lifetimeConstraint"];
 
-  const ix = null as unknown as IInstruction;
+  const ix = null as unknown as Instruction;
 
   // Legacy transactions
   {
+    createTransaction({
+      // version: "legacy", // no `version` set should result in a legacy transaction
+      feePayer: feePayer,
+      instructions: [ix],
+      computeUnitLimit: 0,
+      computeUnitPrice: 0,
+    }) satisfies BaseTransactionMessage<"legacy"> & TransactionMessageWithFeePayer;
+
     createTransaction({
       version: "legacy",
       feePayer: feePayer,
       instructions: [ix],
       computeUnitLimit: 0,
       computeUnitPrice: 0,
-    }) satisfies BaseTransactionMessage<"legacy"> & ITransactionMessageWithFeePayer;
+    }) satisfies BaseTransactionMessage<"legacy"> & TransactionMessageWithFeePayer;
 
     createTransaction({
       version: "legacy",
       feePayer: signer,
       instructions: [ix],
-    }) satisfies BaseTransactionMessage<"legacy"> & ITransactionMessageWithFeePayerSigner;
+    }) satisfies BaseTransactionMessage<"legacy"> & TransactionMessageWithFeePayerSigner;
 
     createTransaction({
       version: "legacy",
@@ -61,7 +69,16 @@ import { createTransaction } from "../core";
       latestBlockhash,
     }) satisfies BaseTransactionMessage<"legacy"> &
       TransactionMessageWithBlockhashLifetime &
-      ITransactionMessageWithFeePayerSigner;
+      TransactionMessageWithFeePayerSigner;
+
+    createTransaction({
+      // version: "legacy", // no `version` set should result in a legacy transaction
+      feePayer: signer,
+      instructions: [ix],
+      latestBlockhash,
+    }) satisfies BaseTransactionMessage<"legacy"> &
+      TransactionMessageWithBlockhashLifetime &
+      TransactionMessageWithFeePayerSigner;
 
     // Should be legacy with a Lifetime and address (aka non Signer)
     const txSignable = createTransaction({
@@ -71,7 +88,7 @@ import { createTransaction } from "../core";
       latestBlockhash,
     }) satisfies BaseTransactionMessage<"legacy"> &
       TransactionMessageWithBlockhashLifetime &
-      ITransactionMessageWithFeePayer;
+      TransactionMessageWithFeePayer;
 
     createTransaction({
       version: "legacy",
@@ -79,7 +96,7 @@ import { createTransaction } from "../core";
       instructions: [ix],
       latestBlockhash,
       // @ts-expect-error Should not be a "fee payer signer"
-    }) satisfies ITransactionMessageWithFeePayerSigner;
+    }) satisfies TransactionMessageWithFeePayerSigner;
 
     // Should be a signable transaction
     signTransactionMessageWithSigners(txSignable);
@@ -93,13 +110,13 @@ import { createTransaction } from "../core";
       instructions: [ix],
       computeUnitLimit: 0,
       computeUnitPrice: 0,
-    }) satisfies BaseTransactionMessage<0> & ITransactionMessageWithFeePayer;
+    }) satisfies BaseTransactionMessage<0> & TransactionMessageWithFeePayer;
 
     createTransaction({
       version: 0,
       feePayer: signer,
       instructions: [ix],
-    }) satisfies BaseTransactionMessage<0> & ITransactionMessageWithFeePayerSigner;
+    }) satisfies BaseTransactionMessage<0> & TransactionMessageWithFeePayerSigner;
 
     const txNotSignable = createTransaction({
       version: 0,
@@ -126,7 +143,7 @@ import { createTransaction } from "../core";
       latestBlockhash,
     }) satisfies BaseTransactionMessage<0> &
       TransactionMessageWithBlockhashLifetime &
-      ITransactionMessageWithFeePayerSigner;
+      TransactionMessageWithFeePayerSigner;
 
     // Should be version 0 with a Lifetime and address (aka non Signer)
     const txSignable = createTransaction({
@@ -134,7 +151,7 @@ import { createTransaction } from "../core";
       feePayer: feePayer,
       instructions: [ix],
       latestBlockhash,
-    }) satisfies BaseTransactionMessage<0> & TransactionMessageWithBlockhashLifetime & ITransactionMessageWithFeePayer;
+    }) satisfies BaseTransactionMessage<0> & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
 
     createTransaction({
       version: 0,
@@ -142,7 +159,7 @@ import { createTransaction } from "../core";
       instructions: [ix],
       latestBlockhash,
       // @ts-expect-error Should not be a "fee payer signer"
-    }) satisfies ITransactionMessageWithFeePayerSigner;
+    }) satisfies TransactionMessageWithFeePayerSigner;
 
     // Should be a signable transaction
     signTransactionMessageWithSigners(txSignable);

--- a/packages/gill/src/core/create-transaction.ts
+++ b/packages/gill/src/core/create-transaction.ts
@@ -3,9 +3,9 @@ import type { Simplify } from "../types";
 import { getSetComputeUnitLimitInstruction, getSetComputeUnitPriceInstruction } from "@solana-program/compute-budget";
 import type {
   Address,
-  ITransactionMessageWithFeePayer,
-  ITransactionMessageWithFeePayerSigner,
   TransactionMessageWithBlockhashLifetime,
+  TransactionMessageWithFeePayer,
+  TransactionMessageWithFeePayerSigner,
   TransactionSigner,
   TransactionVersion,
 } from "@solana/kit";
@@ -27,31 +27,31 @@ import type { CreateTransactionInput, FullTransaction } from "../types/transacti
  */
 export function createTransaction<TVersion extends TransactionVersion, TFeePayer extends TransactionSigner>(
   props: CreateTransactionInput<TVersion, TFeePayer>,
-): FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner>;
+): FullTransaction<TVersion, TransactionMessageWithFeePayerSigner>;
 export function createTransaction<TVersion extends TransactionVersion, TFeePayer extends Address>(
   props: CreateTransactionInput<TVersion, TFeePayer>,
-): FullTransaction<TVersion, ITransactionMessageWithFeePayer>;
+): FullTransaction<TVersion, TransactionMessageWithFeePayer>;
 export function createTransaction<
   TVersion extends TransactionVersion,
   TFeePayer extends TransactionSigner,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
-): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayerSigner, TransactionMessageWithBlockhashLifetime>>;
+): Simplify<FullTransaction<TVersion, TransactionMessageWithFeePayerSigner, TransactionMessageWithBlockhashLifetime>>;
 export function createTransaction<
   TVersion extends TransactionVersion,
   TFeePayer extends Address,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
-): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
+): Simplify<FullTransaction<TVersion, TransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
 export function createTransaction<
   TVersion extends TransactionVersion,
   TFeePayer extends Address | TransactionSigner,
   TLifetimeConstraint extends TransactionMessageWithBlockhashLifetime["lifetimeConstraint"],
 >(
   props: CreateTransactionInput<TVersion, TFeePayer, TLifetimeConstraint>,
-): Simplify<FullTransaction<TVersion, ITransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
+): Simplify<FullTransaction<TVersion, TransactionMessageWithFeePayer, TransactionMessageWithBlockhashLifetime>>;
 export function createTransaction<TVersion extends TransactionVersion, TFeePayer extends Address | TransactionSigner>({
   version,
   feePayer,
@@ -61,10 +61,10 @@ export function createTransaction<TVersion extends TransactionVersion, TFeePayer
   computeUnitPrice,
 }: CreateTransactionInput<TVersion, TFeePayer>): FullTransaction<
   TVersion,
-  ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner
+  TransactionMessageWithFeePayer | TransactionMessageWithFeePayerSigner
 > {
   return pipe(
-    createTransactionMessage({ version }),
+    createTransactionMessage({ version: version ?? ("legacy" as TVersion) }),
     (tx) => {
       const withLifetime = latestBlockhash ? setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx) : tx;
       if (typeof feePayer !== "string" && "address" in feePayer && isTransactionSigner(feePayer)) {
@@ -72,19 +72,21 @@ export function createTransaction<TVersion extends TransactionVersion, TFeePayer
       } else return setTransactionMessageFeePayer(feePayer, withLifetime);
     },
     (tx) => {
-      const withComputeLimit = typeof computeUnitLimit !== "undefined" 
-        ? appendTransactionMessageInstruction(
-            getSetComputeUnitLimitInstruction({ units: Number(computeUnitLimit) }),
-            tx,
-          )
-        : tx;
+      const withComputeLimit =
+        typeof computeUnitLimit !== "undefined"
+          ? appendTransactionMessageInstruction(
+              getSetComputeUnitLimitInstruction({ units: Number(computeUnitLimit) }),
+              tx,
+            )
+          : tx;
 
-      const withComputePrice = typeof computeUnitPrice !== "undefined"
-        ? appendTransactionMessageInstruction(
-            getSetComputeUnitPriceInstruction({ microLamports: Number(computeUnitPrice) }),
-            withComputeLimit,
-          )
-        : withComputeLimit;
+      const withComputePrice =
+        typeof computeUnitPrice !== "undefined"
+          ? appendTransactionMessageInstruction(
+              getSetComputeUnitPriceInstruction({ microLamports: Number(computeUnitPrice) }),
+              withComputeLimit,
+            )
+          : withComputeLimit;
 
       return appendTransactionMessageInstructions(instructions, withComputePrice);
     },

--- a/packages/gill/src/types/transactions.ts
+++ b/packages/gill/src/types/transactions.ts
@@ -1,10 +1,10 @@
 import type {
   Address,
   BaseTransactionMessage,
-  IInstruction,
-  ITransactionMessageWithFeePayer,
-  ITransactionMessageWithFeePayerSigner,
+  Instruction,
   TransactionMessageWithBlockhashLifetime,
+  TransactionMessageWithFeePayer,
+  TransactionMessageWithFeePayerSigner,
   TransactionSigner,
   TransactionVersion,
 } from "@solana/kit";
@@ -19,10 +19,12 @@ export type CreateTransactionInput<
    * Transaction version
    * - `legacy` is commonly used
    * - `0` is needed for use with Address Lookup Tables
+   *
+   * @default `legacy`
    * */
-  version: TVersion;
+  version?: TVersion;
   /** List of instructions for this transaction */
-  instructions: IInstruction[];
+  instructions: Instruction[];
   /** Address or Signer that will pay transaction fees */
   feePayer: TFeePayer;
   /**
@@ -38,7 +40,7 @@ export type CreateTransactionInput<
 
 export type FullTransaction<
   TVersion extends TransactionVersion,
-  TFeePayer extends ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner,
+  TFeePayer extends TransactionMessageWithFeePayer | TransactionMessageWithFeePayerSigner,
   TBlockhashLifetime extends TransactionMessageWithBlockhashLifetime | undefined = undefined,
 > = Simplify<
   BaseTransactionMessage<TVersion> &


### PR DESCRIPTION
### Problem

the `createTransaction` function required a `version` to be provided, where `legacy` is most commonly set anyway

### Summary of Changes

- make `version` optional and default it to `legacy`
- added typesets to cover this 