### PR TITLE
Auto fetch latest blockhash while sending

### DIFF
--- a/.changeset/tender-pears-shave.md
+++ b/.changeset/tender-pears-shave.md
@@ -1,0 +1,6 @@
+---
+"gill": minor
+---
+
+allow transactions without a latest blockhash and auto fetch them when not provided in
+`sendAndConfirmTransactionWithSignersFactory`

--- a/packages/gill/src/__typetests__/send-and-confirm-transaction-with-signers-typetests.ts
+++ b/packages/gill/src/__typetests__/send-and-confirm-transaction-with-signers-typetests.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   GetEpochInfoApi,
+  GetLatestBlockhashApi,
   GetSignatureStatusesApi,
+  Instruction,
   Rpc,
   RpcDevnet,
   RpcMainnet,
@@ -12,14 +14,27 @@ import {
   RpcTestnet,
   SendTransactionApi,
   SignatureNotificationsApi,
+  signTransactionMessageWithSigners,
   SlotNotificationsApi,
+  TransactionSigner,
+  TransactionWithBlockhashLifetime,
+  TransactionWithDurableNonceLifetime,
 } from "@solana/kit";
+import { createTransaction } from "../core";
 import { sendAndConfirmTransactionWithSignersFactory } from "../core/send-and-confirm-transaction-with-signers";
 
-const rpc = null as unknown as Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
-const rpcDevnet = null as unknown as RpcDevnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
-const rpcTestnet = null as unknown as RpcTestnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
-const rpcMainnet = null as unknown as RpcMainnet<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi>;
+const rpc = null as unknown as Rpc<
+  GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi & GetLatestBlockhashApi
+>;
+const rpcDevnet = null as unknown as RpcDevnet<
+  GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi & GetLatestBlockhashApi
+>;
+const rpcTestnet = null as unknown as RpcTestnet<
+  GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi & GetLatestBlockhashApi
+>;
+const rpcMainnet = null as unknown as RpcMainnet<
+  GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi & GetLatestBlockhashApi
+>;
 
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi>;
 const rpcSubscriptionsDevnet = null as unknown as RpcSubscriptionsDevnet<
@@ -31,6 +46,10 @@ const rpcSubscriptionsMainnet = null as unknown as RpcSubscriptionsMainnet<
 const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<
   SignatureNotificationsApi & SlotNotificationsApi
 >;
+
+const signer = "" as unknown as TransactionSigner;
+const instruction = "" as unknown as Instruction;
+const latestBlockhash = "" as unknown as ReturnType<GetLatestBlockhashApi["getLatestBlockhash"]>["value"];
 
 // [DESCRIBE] sendAndConfirmTransactionWithSignersFactory
 {
@@ -62,5 +81,70 @@ const rpcSubscriptionsTestnet = null as unknown as RpcSubscriptionsTestnet<
     sendAndConfirmTransactionWithSignersFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsDevnet });
     // @ts-expect-error
     sendAndConfirmTransactionWithSignersFactory({ rpc: rpcMainnet, rpcSubscriptions: rpcSubscriptionsTestnet });
+  }
+
+  {
+    const sendAndConfirmTransaction = sendAndConfirmTransactionWithSignersFactory({ rpc, rpcSubscriptions });
+
+    const signedTransactionWithBlockhashLifetime = "" as unknown as Awaited<
+      ReturnType<typeof signTransactionMessageWithSigners>
+    > &
+      TransactionWithBlockhashLifetime;
+
+    // Should accept a signed transaction with a blockhash based lifetime
+    sendAndConfirmTransaction(signedTransactionWithBlockhashLifetime);
+
+    const signedTransactionWithNonceLifetime = "" as unknown as Awaited<
+      ReturnType<typeof signTransactionMessageWithSigners>
+    > &
+      TransactionWithDurableNonceLifetime;
+
+    // @ts-expect-error - durable nonce transactions are not currently supported
+    // todo: add support for nonce based transactions
+    sendAndConfirmTransaction(signedTransactionWithNonceLifetime);
+
+    // Should accept a legacy transaction, with or without a latest blockhash
+    {
+      const transactionWithoutLatestBlockhash = createTransaction({
+        version: "legacy",
+        feePayer: signer,
+        instructions: [instruction],
+      });
+
+      const transactionWithLatestBlockhash = createTransaction({
+        version: "legacy",
+        feePayer: signer,
+        instructions: [instruction],
+        latestBlockhash,
+      });
+
+      // Should accept a signable transaction WITHOUT the latest blockhash
+      sendAndConfirmTransaction(transactionWithoutLatestBlockhash);
+
+      // Should accept a signable transaction WITH the latest blockhash
+      sendAndConfirmTransaction(transactionWithLatestBlockhash);
+    }
+
+    // Should accept a versioned transaction, with or without a latest blockhash
+    {
+      const transactionWithoutLatestBlockhash = createTransaction({
+        version: 0,
+        feePayer: signer,
+        instructions: [instruction],
+      });
+
+      const transactionWithLatestBlockhash = createTransaction({
+        version: 0,
+        feePayer: signer,
+        instructions: [instruction],
+        latestBlockhash,
+      });
+
+      // Should accept a signable transaction WITHOUT the latest blockhash
+      sendAndConfirmTransaction(transactionWithoutLatestBlockhash);
+
+      // Should accept a signable transaction WITH the latest blockhash
+      sendAndConfirmTransaction(transactionWithLatestBlockhash);
+    }
   }
 }

--- a/packages/gill/src/core/send-and-confirm-transaction-with-signers.ts
+++ b/packages/gill/src/core/send-and-confirm-transaction-with-signers.ts
@@ -1,7 +1,9 @@
 import type {
+  BaseTransactionMessage,
   CompilableTransactionMessage,
   FullySignedTransaction,
   GetEpochInfoApi,
+  GetLatestBlockhashApi,
   GetSignatureStatusesApi,
   Rpc,
   RpcSubscriptions,
@@ -9,36 +11,31 @@ import type {
   Signature,
   SignatureNotificationsApi,
   SlotNotificationsApi,
+  TransactionMessageWithFeePayer,
   TransactionWithBlockhashLifetime,
 } from "@solana/kit";
 import {
+  assertIsTransactionMessageWithBlockhashLifetime,
   Commitment,
   getBase64EncodedWireTransaction,
   getSignatureFromTransaction,
   sendAndConfirmTransactionFactory,
+  setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
 } from "@solana/kit";
 import { type waitForRecentTransactionConfirmation } from "@solana/transaction-confirmation";
 import { debug } from "./debug";
 import { getExplorerLink } from "./explorer";
 
-interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
-  extends SendTransactionBaseConfig,
-    SendTransactionConfigWithoutEncoding {
+interface SendAndConfirmTransactionWithBlockhashLifetimeConfig extends SendTransactionConfigWithoutEncoding {
   confirmRecentTransaction: (
     config: Omit<
       Parameters<typeof waitForRecentTransactionConfirmation>[0],
       "getBlockHeightExceedencePromise" | "getRecentSignatureConfirmationPromise"
     >,
   ) => Promise<void>;
-  transaction: FullySignedTransaction & TransactionWithBlockhashLifetime;
-}
-
-interface SendTransactionBaseConfig extends SendTransactionConfigWithoutEncoding {
   abortSignal?: AbortSignal;
   commitment: Commitment;
-  rpc: Rpc<SendTransactionApi>;
-  transaction: FullySignedTransaction;
 }
 
 type SendTransactionConfigWithoutEncoding = Omit<
@@ -46,8 +43,13 @@ type SendTransactionConfigWithoutEncoding = Omit<
   "encoding"
 >;
 
+type SendableTransaction =
+  | CompilableTransactionMessage
+  | (FullySignedTransaction & TransactionWithBlockhashLifetime)
+  | (BaseTransactionMessage & TransactionMessageWithFeePayer);
+
 export type SendAndConfirmTransactionWithSignersFunction = (
-  transaction: (FullySignedTransaction & TransactionWithBlockhashLifetime) | CompilableTransactionMessage,
+  transaction: SendableTransaction,
   config?: Omit<
     SendAndConfirmTransactionWithBlockhashLifetimeConfig,
     "confirmRecentTransaction" | "rpc" | "transaction"
@@ -55,7 +57,7 @@ export type SendAndConfirmTransactionWithSignersFunction = (
 ) => Promise<Signature>;
 
 type SendAndConfirmTransactionWithSignersFactoryConfig<TCluster> = {
-  rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & {
+  rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi & GetLatestBlockhashApi> & {
     "~cluster"?: TCluster;
   };
   rpcSubscriptions: RpcSubscriptions<SignatureNotificationsApi & SlotNotificationsApi> & {
@@ -89,6 +91,11 @@ export function sendAndConfirmTransactionWithSignersFactory<
   const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
   return async function sendAndConfirmTransactionWithSigners(transaction, config = { commitment: "confirmed" }) {
     if ("messageBytes" in transaction == false) {
+      if ("lifetimeConstraint" in transaction === false) {
+        const { value: latestBlockhash } = await rpc.getLatestBlockhash().send({ abortSignal: config.abortSignal });
+        transaction = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, transaction);
+        assertIsTransactionMessageWithBlockhashLifetime(transaction);
+      }
       transaction = (await signTransactionMessageWithSigners(transaction)) as Readonly<
         FullySignedTransaction & TransactionWithBlockhashLifetime
       >;

--- a/packages/gill/src/types/rpc.ts
+++ b/packages/gill/src/types/rpc.ts
@@ -42,7 +42,9 @@ export type SolanaClient<TClusterUrl extends ModifiedClusterUrl | string = strin
   /** Used to make RPC websocket calls to your RPC provider */
   rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi> & TClusterUrl;
   /**
-   * Send and confirm a transaction to the network (including signing with available Signers)
+   * Send and confirm a transaction to the network (including signing with available Signers).
+   *
+   * If the `transaction` does not already have a latest blockhash (and is not already signed), it will be automatically retrieved and applied.
    *
    * Default commitment level: `confirmed`
    */


### PR DESCRIPTION
### Problem

the `sendAndConfirmTransactionWithSignersFactory` requires a latest blockhash to be provided whereas it could also fetch it itself.

### Summary of Changes

- relaxed types for the function
- auto fetch latest blockhash when not provided