### PR TITLE
homepage link and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,17 @@ Gill is built on top of the modern javascript libraries for Solana built by Anza
 [@solana/kit](https://github.com/anza-xyz/kit) (formerly known as "web3.js v2"). By utilizing the same types and
 functions under the hood, `gill` is compatible with `kit`. See [Replacing Kit with gill](#replace-kit-with-gill).
 
-> For a comparison of using gill vs web3js v2, take a look at the
+> For a comparison of using gill vs `@solana/kit`, take a look at the
+> [gill vs @solana/kit comparison docs](https://gill.site/docs/compare/kit) and the
 > [comparison examples](https://github.com/DecalLabs/gill/tree/master/examples/get-started#comparison-of-gill-vs-solanakit-aka-web3js-v2).
+
+## Documentation
+
+You can find the gill library docs here:
+
+- [gill docs site](https://gill.site)
+- [gill setup guide](https://gill.site/docs#quick-start)
+- [gill API references](https://gill.site/api)
 
 ## Installation
 
@@ -85,12 +94,16 @@ You can find [transaction builders](#transaction-builders) for common tasks, inc
 - [Minting tokens to a destination wallet](#mint-tokens-to-a-destination-wallet)
 - [Transfer tokens to a destination wallet](#transfer-tokens-to-a-destination-wallet)
 
-For troubleshooting and debugging your Solana transactions, see [Debug mode](#debug-mode) below.
+For troubleshooting and debugging your Solana transactions, see [Debug mode](#debug-mode) below and the gill docs for
+[Debug Mode](https://gill.site/docs/debug-mode).
 
 > You can also consult the documentation for Anza's [JavaScript client](https://github.com/anza-xyz/solana-web3.js)
 > library for more information and helpful resources.
 
 ### Generating keypairs and signers
+
+See also: the docs on
+[Generating a keypair signer](https://gill.site/docs/getting-started/signers#generating-a-keypair-signer).
 
 For most "signing" operations, you will need a `KeyPairSigner` instance, which can be used to sign transactions and
 messages.
@@ -109,6 +122,9 @@ const signer: KeyPairSigner = await generateKeyPairSigner();
 
 ### Generating extractable keypairs and signers
 
+See also: the docs on
+[Generating extractable keypairs and signers](https://gill.site/docs/getting-started/signers#generating-extractable-keypairs-and-signers).
+
 Extractable keypairs are less secure and should not be used unless you REALLY need to save the key for some reason.
 Since there are a few useful cases for saving these keypairs, gill contains a separate explicit function to generate
 these extractable keypairs.
@@ -126,6 +142,8 @@ const signer: KeyPairSigner = await generateExtractableKeyPairSigner();
 > extract the key material (like if you are going to save the key to a file).
 
 ### Create a Solana RPC connection
+
+See also: the docs on [how to create a Solana client](https://gill.site/docs/getting-started/client)
 
 Create a Solana `rpc` and `rpcSubscriptions` client for any RPC URL or standard Solana network moniker (i.e. `devnet`,
 `localnet`, `mainnet` etc).
@@ -660,6 +678,8 @@ const transferTokensTx = await buildTransferTokensTransaction({
 
 ## Debug mode
 
+See also: the docs for [Debug Mode](https://gill.site/docs/debug-mode)
+
 Within `gill`, you can enable "debug mode" to automatically log additional information that will be helpful in
 troubleshooting your transactions.
 
@@ -775,6 +795,9 @@ package to use in conjunction with gill:
 - [Vote program](https://github.com/solana-program/vote) - `@solana-program/vote`
 
 ### Generate a program client from an IDL
+
+See also: this official gill docs and guide on
+[how to generate a program client with codama](https://gill.site/docs/guides/codama)
 
 If you want to easily interact with any custom program with this library, you can use
 [Codama](https://github.com/codama-idl/codama) to generate a compatible JavaScript/TypeScript client using its IDL. You

--- a/docs/content/docs/examples.mdx
+++ b/docs/content/docs/examples.mdx
@@ -1,0 +1,98 @@
+---
+title: Examples
+description:
+  Collection of example scripts and code snippets on how to use gill, the Solana JavaScript SDK.
+---
+
+Listed here and in gill's open source repository, you can find a collection of example scripts and
+code snippets that demonstrate how to accomplish various common tasks for Solana developers.
+
+[github.com/DecalLabs/gill/tree/master/examples](https://github.com/DecalLabs/gill/tree/master/examples)
+
+## Get started with the basics
+
+Inside of the gill repository, you can find the `get-started` directory that contains gill examples
+scripts on the following:
+
+### intro.ts
+
+<Callout title="Source Code Link">
+  https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/intro.ts
+</Callout>
+
+A brief introduction to the `gill` library. Demonstrating and explaining the commonly used tasks
+involved to interact with the Solana blockchain, including:
+
+- load a keypair signer from the local filesystem
+- create an rpc connection to the blockchain
+- creating basic instructions (like the memo instruction)
+- getting the latest blockhash
+- building a complete transaction
+- signing the transaction with the loaded local keypair signer
+- getting the signature of a transaction (even before it is sent)
+- logging Solana Explorer links
+- sending and confirming a transaction
+
+These are all the most basic tasks required for any application sending transaction to the Solana
+blockchain.
+
+### airdrop.ts
+
+<Callout title="Source Code Link">
+  https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/airdrop.ts
+</Callout>
+
+Demonstrates how to create a client connection to the Solana blockchain on a test cluster (e.g.
+`devnet`, `testnet`, or `localnet`) and request airdrops of testing SOL tokens to a wallet address.
+
+### tokens.ts
+
+<Callout title="Source Code Link">
+  https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/tokens.ts
+</Callout>
+
+Demonstrates how to use gill's "transaction builders" to create a brand new Solana token (with
+onchain metadata) and then mint tokens to another user's wallet:
+
+- load a keypair signer from the local filesystem
+- create an rpc connection to the blockchain
+- getting the latest blockhash
+- build an optimized transaction to create a token
+- sign, send, and confirm that "create token" transaction
+- build an optimized transaction to mint
+- sign, send, and confirm that "mint tokens" transaction
+
+### reference-keys.ts
+
+<Callout title="Source Code Link">
+  https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/reference-keys.ts
+</Callout>
+
+This script demonstrates the process to add a reference key into a transaction.
+
+Adding reference keys to transactions allows developers to be able track the completion of
+transactions given to users, without knowing the signature ahead of time. Then, perform any desired
+logic after detection of the reference keyed transaction landing onchain.
+
+Most notably utilized within SolanaPay and Blinks.
+
+See also: the gill docs for [Reference Keys](https://gill.site/docs/guides/reference-keys) for more
+information.
+
+### Comparison between @solana/kit and gill
+
+You can find comparison scripts that demonstrates some of the differences between
+[gill](https://github.com/DecalLabs/gill) and [@solana/kit](https://github.com/anza-xyz/kit)
+(formerly known as "web3.js v2").
+
+<Callout>
+  Find a more comprehensive comparison in [gill vs @solana/kit comparison
+  docs](https://gill.site/docs/compare/kit)
+</Callout>
+
+Both scripts accomplish the same task: send an optimized transaction to the Solana blockchain.
+
+- Using gill -
+  [`basic.ts`](https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/basic.ts)
+- Using web3js v2 -
+  [`basic-compare.ts`](https://github.com/DecalLabs/gill/blob/master/examples/get-started/src/basic-compare.ts)

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -6,6 +6,7 @@
     "---Introduction---",
     "index",
     "typescript",
+    "examples",
     "---Getting Started---",
     "...getting-started",
     "---Comparisons---",

--- a/examples/get-started/README.md
+++ b/examples/get-started/README.md
@@ -93,6 +93,10 @@ wallet:
 
 This script demonstrates the process to add a reference key into a transaction.
 
+> See the gill docs for
+> [Reference Keys](https://gill.site/docs/guides/reference-keys) for more
+> information.
+
 Adding reference keys to transactions allows developers to be able track the
 completion of transactions given to users, without knowing the signature ahead
 of time. Then, perform any desired logic after detection of the reference keyed
@@ -105,6 +109,9 @@ Most notably utilized within SolanaPay and Blinks.
 You can find comparison scripts that demonstrates some of the differences
 between [gill](https://github.com/DecalLabs/gill) and
 [@solana/kit](https://github.com/anza-xyz/kit) (formerly known as "web3.js v2").
+
+> Find a more comprehensive comparison in
+> [gill vs @solana/kit comparison docs](https://gill.site/docs/compare/kit)
 
 Both scripts accomplish the same task: send an optimized transaction to the
 Solana blockchain.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "packageManager": "pnpm@9.1.0",
   "author": "Solana Foundation DevRel <devrel@solana.org>",
-  "homepage": "https://github.com/DecalLabs/gill#readme",
+  "homepage": "https://gill.site",
   "bugs": {
     "url": "https://github.com/DecalLabs/gill/issues"
   },

--- a/packages/gill/README.md
+++ b/packages/gill/README.md
@@ -26,8 +26,17 @@ Gill is built on top of the modern javascript libraries for Solana built by Anza
 [@solana/kit](https://github.com/anza-xyz/kit) (formerly known as "web3.js v2"). By utilizing the same types and
 functions under the hood, `gill` is compatible with `kit`. See [Replacing Kit with gill](#replace-kit-with-gill).
 
-> For a comparison of using gill vs web3js v2, take a look at the
+> For a comparison of using gill vs `@solana/kit`, take a look at the
+> [gill vs @solana/kit comparison docs](https://gill.site/docs/compare/kit) and the
 > [comparison examples](https://github.com/DecalLabs/gill/tree/master/examples/get-started#comparison-of-gill-vs-solanakit-aka-web3js-v2).
+
+## Documentation
+
+You can find the gill library docs here:
+
+- [gill docs site](https://gill.site)
+- [gill setup guide](https://gill.site/docs#quick-start)
+- [gill API references](https://gill.site/api)
 
 ## Installation
 
@@ -85,12 +94,16 @@ You can find [transaction builders](#transaction-builders) for common tasks, inc
 - [Minting tokens to a destination wallet](#mint-tokens-to-a-destination-wallet)
 - [Transfer tokens to a destination wallet](#transfer-tokens-to-a-destination-wallet)
 
-For troubleshooting and debugging your Solana transactions, see [Debug mode](#debug-mode) below.
+For troubleshooting and debugging your Solana transactions, see [Debug mode](#debug-mode) below and the gill docs for
+[Debug Mode](https://gill.site/docs/debug-mode).
 
 > You can also consult the documentation for Anza's [JavaScript client](https://github.com/anza-xyz/solana-web3.js)
 > library for more information and helpful resources.
 
 ### Generating keypairs and signers
+
+See also: the docs on
+[Generating a keypair signer](https://gill.site/docs/getting-started/signers#generating-a-keypair-signer).
 
 For most "signing" operations, you will need a `KeyPairSigner` instance, which can be used to sign transactions and
 messages.
@@ -109,6 +122,9 @@ const signer: KeyPairSigner = await generateKeyPairSigner();
 
 ### Generating extractable keypairs and signers
 
+See also: the docs on
+[Generating extractable keypairs and signers](https://gill.site/docs/getting-started/signers#generating-extractable-keypairs-and-signers).
+
 Extractable keypairs are less secure and should not be used unless you REALLY need to save the key for some reason.
 Since there are a few useful cases for saving these keypairs, gill contains a separate explicit function to generate
 these extractable keypairs.
@@ -126,6 +142,8 @@ const signer: KeyPairSigner = await generateExtractableKeyPairSigner();
 > extract the key material (like if you are going to save the key to a file).
 
 ### Create a Solana RPC connection
+
+See also: the docs on [how to create a Solana client](https://gill.site/docs/getting-started/client)
 
 Create a Solana `rpc` and `rpcSubscriptions` client for any RPC URL or standard Solana network moniker (i.e. `devnet`,
 `localnet`, `mainnet` etc).
@@ -660,6 +678,8 @@ const transferTokensTx = await buildTransferTokensTransaction({
 
 ## Debug mode
 
+See also: the docs for [Debug Mode](https://gill.site/docs/debug-mode)
+
 Within `gill`, you can enable "debug mode" to automatically log additional information that will be helpful in
 troubleshooting your transactions.
 
@@ -775,6 +795,9 @@ package to use in conjunction with gill:
 - [Vote program](https://github.com/solana-program/vote) - `@solana-program/vote`
 
 ### Generate a program client from an IDL
+
+See also: this official gill docs and guide on
+[how to generate a program client with codama](https://gill.site/docs/guides/codama)
 
 If you want to easily interact with any custom program with this library, you can use
 [Codama](https://github.com/codama-idl/codama) to generate a compatible JavaScript/TypeScript client using its IDL. You

--- a/packages/gill/package.json
+++ b/packages/gill/package.json
@@ -94,7 +94,7 @@
     "treeshake"
   ],
   "author": "Solana Foundation DevRel <devrel@solana.org>",
-  "homepage": "https://github.com/DecalLabs/gill#readme",
+  "homepage": "https://gill.site",
   "bugs": {
     "url": "https://github.com/DecalLabs/gill/issues"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
     "wagmi"
   ],
   "author": "Solana Foundation DevRel <devrel@solana.org>",
-  "homepage": "https://github.com/DecalLabs/gill#readme",
+  "homepage": "https://gill.site",
   "bugs": {
     "url": "https://github.com/DecalLabs/gill/issues"
   },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -57,7 +57,7 @@
     "web3"
   ],
   "author": "Solana Foundation DevRel <devrel@solana.org>",
-  "homepage": "https://github.com/DecalLabs/gill#readme",
+  "homepage": "https://gill.site",
   "bugs": {
     "url": "https://github.com/DecalLabs/gill/issues"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -57,7 +57,7 @@
     "web3"
   ],
   "author": "Solana Foundation DevRel <devrel@solana.org>",
-  "homepage": "https://github.com/DecalLabs/gill#readme",
+  "homepage": "https://gill.site",
   "bugs": {
     "url": "https://github.com/DecalLabs/gill/issues"
   },


### PR DESCRIPTION
### Summary of Changes

- added the gill docs site as the `homepage` for the packages
- added an examples page to the docs
- sprinkled in some docs links into the core readme

Fixes: #181