### PR TITLE
feat: add decimal places support to lamportsToSol function

### DIFF
--- a/packages/gill/src/core/utils.ts
+++ b/packages/gill/src/core/utils.ts
@@ -43,8 +43,14 @@ export function checkedTransactionSigner<TAddress extends string = string>(
 
 /**
  * Convert a lamport number to the human readable string of a SOL value
+ * @param lamports - The amount in lamports
+ * @param decimals - Number of decimal places to show (default: 9, max: 9)
  */
-export function lamportsToSol(lamports: bigint | number): string {
-  // @ts-expect-error This format is valid
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 9 }).format(`${lamports}E-9`);
+export function lamportsToSol(lamports: bigint | number, decimals: number = 9): string {
+  const maxDecimals = Math.min(decimals, 9);
+  const solValue = Number(lamports) / 1_000_000_000;
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: maxDecimals,
+    minimumFractionDigits: 0,
+  }).format(solValue);
 }


### PR DESCRIPTION
## Summary
Quality of life update to the `lamportsToSol` function to support configurable decimal places.

## Changes
- Added optional `decimals` parameter (default: 9, max: 9)
- Properly converts lamports to SOL using division instead of string manipulation
- Uses `Intl.NumberFormat` for consistent number formatting

## Usage
```typescript
// Default behavior (up to 9 decimal places)
lamportsToSol(1234567890) // "1.23456789"

// Custom decimal places
lamportsToSol(1234567890, 2) // "1.23"
lamportsToSol(1234567890, 4) // "1.2346"
```

## Test plan
- [x] Updated function builds successfully
- [x] Maintains backward compatibility (default behavior unchanged)
- [ ] Existing tests pass